### PR TITLE
[feat] 워크플로우 공유 상세 페이지에 그래프 미리보기 기능 추가

### DIFF
--- a/src/features/flow/components/sharing/business/workflow-share-detail-content.tsx
+++ b/src/features/flow/components/sharing/business/workflow-share-detail-content.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { WorkflowSharePurchaseDialog } from "@/features/flow/components/sharing/business/workflow-share-purchase-dialog";
 import { WorkflowShareHero } from "@/features/flow/components/sharing/ui/workflow-share-hero";
+import { WorkflowGraphPreview } from "@/features/flow/components/sharing/ui/workflow-graph-preview";
 import { WorkflowShareSection } from "@/features/flow/components/sharing/ui/workflow-share-section";
 import type { WorkflowShareDetail } from "@/features/flow/types/workflow-sharing";
 import { api } from "@/lib/api-client";
@@ -169,17 +170,29 @@ export function WorkflowShareDetailContent({
         title="워크플로우 설명"
         description="워크플로우 세부 설명"
       >
-        <div className="space-y-3 text-sm text-muted-foreground">
-          <p className="whitespace-pre-line">
-            {shareState.workflowDescription ??
-              "워크플로우 설명이 아직 작성되지 않았습니다."}
-          </p>
-          <div className="flex flex-wrap gap-2">
-            {shareState.tags.map((tag) => (
-              <Badge key={`${shareState.shareId}-${tag}`} variant="outline">
-                #{tag}
-              </Badge>
-            ))}
+        <div className="space-y-6">
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <p className="whitespace-pre-line">
+              {shareState.workflowDescription ??
+                "워크플로우 설명이 아직 작성되지 않았습니다."}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {shareState.tags.map((tag) => (
+                <Badge key={`${shareState.shareId}-${tag}`} variant="outline">
+                  #{tag}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold text-foreground">
+              워크플로우 구조 미리보기
+            </h3>
+            <WorkflowGraphPreview
+              nodes={shareState.nodes}
+              edges={shareState.edges}
+            />
           </div>
         </div>
       </WorkflowShareSection>

--- a/src/features/flow/components/sharing/ui/workflow-graph-preview.tsx
+++ b/src/features/flow/components/sharing/ui/workflow-graph-preview.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { type CSSProperties, useMemo } from "react";
+import {
+  Background,
+  Controls,
+  Handle,
+  type NodeProps,
+  type NodeTypes,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { edgeTypes } from "@/features/flow/components/nodes/custom-edge";
+import type { SchemaEdge, SchemaNode } from "@/features/flow/types/graph";
+
+type PreviewHandleDefinition = {
+  id: string;
+  type: "source" | "target";
+  position: Position;
+  size?: "small" | "large";
+  style?: CSSProperties;
+};
+
+const handleClassName = (
+  type: "source" | "target",
+  size?: "small" | "large",
+) => {
+  const sizeClass = size === "small" ? "h-2 w-2" : "h-3 w-3";
+  const colorClass = type === "source" ? "bg-emerald-500" : "bg-violet-500";
+
+  return `${sizeClass} ${colorClass} border-2 border-white shadow-sm`;
+};
+
+const createPreviewNode = (
+  handles: PreviewHandleDefinition[],
+): React.FC<NodeProps<SchemaNode>> => {
+  const PreviewNodeComponent: React.FC<NodeProps<SchemaNode>> = ({ data }) => (
+    <div className="relative flex h-10 w-16 items-center justify-center gap-3 rounded-lg border-2 border-slate-200 bg-white p-3 shadow-sm">
+      {handles.map((handle) => (
+        <Handle
+          key={handle.id}
+          id={handle.id}
+          type={handle.type}
+          position={handle.position}
+          isConnectable={false}
+          className={handleClassName(handle.type, handle.size)}
+          style={handle.style}
+        />
+      ))}
+      <div className="line-clamp-1 text-xs text-slate-500">
+        {data?.job || "작업"}
+      </div>
+    </div>
+  );
+
+  PreviewNodeComponent.displayName = "PreviewNode";
+
+  return PreviewNodeComponent;
+};
+
+const previewNodeTypes: NodeTypes = {
+  inputNode: createPreviewNode([
+    { type: "source", position: Position.Right, id: "right" },
+  ]),
+  outputNode: createPreviewNode([
+    { type: "target", position: Position.Left, id: "left" },
+  ]),
+  chatNode: createPreviewNode([
+    { type: "target", position: Position.Left, id: "left" },
+    { type: "source", position: Position.Right, id: "right" },
+  ]),
+  searchNode: createPreviewNode([
+    { type: "target", position: Position.Left, id: "left" },
+    { type: "source", position: Position.Right, id: "right" },
+  ]),
+  messageNode: createPreviewNode([
+    { type: "target", position: Position.Left, id: "left" },
+    { type: "source", position: Position.Right, id: "right" },
+  ]),
+  singleInputMultiOutput: createPreviewNode([
+    { type: "target", position: Position.Left, id: "input" },
+    {
+      type: "source",
+      position: Position.Right,
+      id: "output-1",
+      size: "small",
+      style: { top: "25%" },
+    },
+    {
+      type: "source",
+      position: Position.Right,
+      id: "output-2",
+      size: "small",
+      style: { top: "50%" },
+    },
+    {
+      type: "source",
+      position: Position.Right,
+      id: "output-3",
+      size: "small",
+      style: { top: "75%" },
+    },
+  ]),
+  multiInputSingleOutput: createPreviewNode([
+    {
+      type: "target",
+      position: Position.Left,
+      id: "input-1",
+      size: "small",
+      style: { top: "25%" },
+    },
+    {
+      type: "target",
+      position: Position.Left,
+      id: "input-2",
+      size: "small",
+      style: { top: "50%" },
+    },
+    {
+      type: "target",
+      position: Position.Left,
+      id: "input-3",
+      size: "small",
+      style: { top: "75%" },
+    },
+    { type: "source", position: Position.Right, id: "output" },
+  ]),
+};
+
+interface WorkflowGraphPreviewProps {
+  nodes: SchemaNode[];
+  edges: SchemaEdge[];
+}
+
+export function WorkflowGraphPreview({
+  nodes,
+  edges,
+}: WorkflowGraphPreviewProps) {
+  const memoizedNodes = useMemo(() => nodes, [nodes]);
+  const memoizedEdges = useMemo(() => edges, [edges]);
+
+  return (
+    <div className="h-96 w-full rounded-lg border bg-slate-50">
+      <ReactFlowProvider>
+        <ReactFlow<SchemaNode, SchemaEdge>
+          nodes={memoizedNodes}
+          edges={memoizedEdges}
+          nodeTypes={previewNodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          fitViewOptions={{
+            padding: 0.2,
+            includeHiddenNodes: false,
+          }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          panOnDrag={false}
+          zoomOnScroll={false}
+          zoomOnPinch={false}
+          zoomOnDoubleClick={false}
+          className="workflow-graph-preview"
+        >
+          <Background />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </ReactFlowProvider>
+    </div>
+  );
+}

--- a/src/features/flow/types/workflow-sharing.ts
+++ b/src/features/flow/types/workflow-sharing.ts
@@ -1,6 +1,7 @@
 import type { InferSelectModel } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
+import type { SchemaEdge, SchemaNode } from "@/features/flow/types/graph";
 import { workflowShares } from "@/features/flow/db/schema";
 
 export type WorkflowShare = InferSelectModel<typeof workflowShares>;
@@ -60,5 +61,7 @@ export interface WorkflowShareViewerContext {
 }
 
 export interface WorkflowShareDetail extends WorkflowShareSummary {
+  nodes: SchemaNode[];
+  edges: SchemaEdge[];
   viewerContext?: WorkflowShareViewerContext;
 }


### PR DESCRIPTION
워크플로우 공유 상세 페이지에 워크플로우 구조를 시각적으로 보여주는
그래프 미리보기 컴포넌트를 추가하고, 기존 설명 섹션과 통합함.
ReactFlow를 사용하여 노드와 엣지를 기반으로 워크플로우 구조를
렌더링하며, 다양한 노드 타입에 대한 미리보기 기능을 구현함.